### PR TITLE
Transmog UI: Enhancements & Fixes

### DIFF
--- a/Narcissus/Modules/TransmogUI/CustomSetsTab.lua
+++ b/Narcissus/Modules/TransmogUI/CustomSetsTab.lua
@@ -252,11 +252,9 @@ do
                 end
             end
 
-            if data.customSetID then
-                C_TransmogOutfitInfo.SetOutfitToCustomSet(data.customSetID);
-            else
-                TransmogUIManager:SetPendingFromTransmogInfoList(data.transmogInfoList);
-            end
+            --SetOutfitToCustomSet skips illusions and mis-resolves weapon option/shoulder-split.
+            --Apply manually here too, for parity with shared and alt-character sets.
+            TransmogUIManager:SetPendingFromTransmogInfoList(data.transmogInfoList);
             PlaySound(SOUNDKIT.UI_TRANSMOG_ITEM_CLICK);
 
             CallbackRegistry:Trigger("StaticPopup.CloseAll");

--- a/Narcissus/Modules/TransmogUI/Preload.lua
+++ b/Narcissus/Modules/TransmogUI/Preload.lua
@@ -9,6 +9,12 @@ local TransmogDataProvider = addon.TransmogDataProvider;
 local GetSourceInfo = C_TransmogCollection.GetSourceInfo;
 local GetAppearanceInfoBySource = C_TransmogCollection.GetAppearanceInfoBySource;
 local GetTransmogOutfitSlotFromInventorySlot = C_TransmogOutfitInfo and C_TransmogOutfitInfo.GetTransmogOutfitSlotFromInventorySlot;
+local GetEquippedSlotOptionFromTransmogSlot = C_TransmogOutfitInfo and C_TransmogOutfitInfo.GetEquippedSlotOptionFromTransmogSlot;
+local GetWeaponOptionsForSlot = C_TransmogOutfitInfo and C_TransmogOutfitInfo.GetWeaponOptionsForSlot;
+local SetViewedWeaponOptionForSlot = C_TransmogOutfitInfo and C_TransmogOutfitInfo.SetViewedWeaponOptionForSlot;
+local GetPairedArtifactAppearance = C_TransmogCollection.GetPairedArtifactAppearance;
+local SetSecondarySlotState = C_TransmogOutfitInfo and C_TransmogOutfitInfo.SetSecondarySlotState;
+local MainHandTransmogIsPairedWeapon = Constants.Transmog.MainHandTransmogIsPairedWeapon;
 local IsAppearanceHiddenVisual = C_TransmogCollection.IsAppearanceHiddenVisual;
 local SetPendingTransmog =  C_TransmogOutfitInfo and C_TransmogOutfitInfo.SetPendingTransmog;
 local ipairs = ipairs;
@@ -88,10 +94,29 @@ local TransmogInvSlots = {
 local function ApplyTransmog(invSlotID, slot, transmogID, illusionID)
     local transmogType, option, displayType;
 
-    --if invSlotID == 16 or invSlotID == 17 then
-    --    option = C_TransmogOutfitInfo.GetEquippedSlotOptionFromTransmogSlot(slot);
-    --    SetPendingTransmog(slot, Enum.TransmogType.Appearance, option, 0, Enum.TransmogOutfitDisplayType.Unassigned);
-    --end
+    if invSlotID == 16 or invSlotID == 17 then
+        --Weapon option isn't saved, so resolve it live. Artifact appearances need their own option, not generic.
+        if slot and transmogID and TransmogDataProvider:IsLegionArtifactBySourceID(transmogID) then
+            local _, artifactOptionsInfo = GetWeaponOptionsForSlot(slot);
+            if artifactOptionsInfo then
+                for _, optionInfo in ipairs(artifactOptionsInfo) do
+                    if optionInfo.enabled then
+                        option = optionInfo.weaponOption;
+                        break;
+                    end
+                end
+            end
+        end
+
+        if not option then
+            option = slot and GetEquippedSlotOptionFromTransmogSlot(slot);
+        end
+
+        if slot and option then
+            --A widget rebuild can reset this slot's viewed option to generic, so re-assert ours here.
+            SetViewedWeaponOptionForSlot(slot, option);
+        end
+    end
 
     if not option then
         option = Enum.TransmogOutfitSlotOption.None;
@@ -133,8 +158,7 @@ local function ApplyTransmog(invSlotID, slot, transmogID, illusionID)
 end
 
 function TransmogUIManager:SetPendingFromTransmogInfoList(transmogInfoList)
-    --WoW uses C_TransmogOutfitInfo.SetOutfitToCustomSet(customSetID) to directly apply the sets
-    --But we need to do it by slot
+    --Applied per-slot rather than via SetOutfitToCustomSet, for correct illusion/weapon option/shoulder-split
 
     for invSlotID, transmogInfo in ipairs(transmogInfoList) do
         if not IgnoredInvSlots[invSlotID] then
@@ -146,7 +170,20 @@ function TransmogUIManager:SetPendingFromTransmogInfoList(transmogInfoList)
                 illusionID = nil;
             end
 
+            if invSlotID == 17 then
+                --Paired Legion Artifact off-hands derive their appearance from the main-hand, not their own.
+                local mainHandInfo = transmogInfoList[16];
+                if mainHandInfo and mainHandInfo.secondaryAppearanceID == MainHandTransmogIsPairedWeapon then
+                    transmogID = GetPairedArtifactAppearance(mainHandInfo.appearanceID) or transmogID;
+                end
+            end
+
             if invSlotID == 3 then
+                --Must run before the appearances below are applied. Toggling it afterward
+                --wipes the left shoulder's pending value.
+                local needsSplitShoulders = secondaryAppearanceID ~= 0 and secondaryAppearanceID ~= transmogID;
+                SetSecondarySlotState(Enum.TransmogOutfitSlot.ShoulderRight, needsSplitShoulders);
+
                 ApplyTransmog(invSlotID, Enum.TransmogOutfitSlot.ShoulderRight, transmogID);
                 if secondaryAppearanceID == 0 then
                     secondaryAppearanceID = transmogID;

--- a/Narcissus/Modules/TransmogUI/Preload.lua
+++ b/Narcissus/Modules/TransmogUI/Preload.lua
@@ -12,6 +12,7 @@ local GetTransmogOutfitSlotFromInventorySlot = C_TransmogOutfitInfo and C_Transm
 local GetEquippedSlotOptionFromTransmogSlot = C_TransmogOutfitInfo and C_TransmogOutfitInfo.GetEquippedSlotOptionFromTransmogSlot;
 local GetWeaponOptionsForSlot = C_TransmogOutfitInfo and C_TransmogOutfitInfo.GetWeaponOptionsForSlot;
 local SetViewedWeaponOptionForSlot = C_TransmogOutfitInfo and C_TransmogOutfitInfo.SetViewedWeaponOptionForSlot;
+local GetViewedOutfitSlotInfo = C_TransmogOutfitInfo and C_TransmogOutfitInfo.GetViewedOutfitSlotInfo;
 local GetPairedArtifactAppearance = C_TransmogCollection.GetPairedArtifactAppearance;
 local SetSecondarySlotState = C_TransmogOutfitInfo and C_TransmogOutfitInfo.SetSecondarySlotState;
 local MainHandTransmogIsPairedWeapon = Constants.Transmog.MainHandTransmogIsPairedWeapon;
@@ -95,14 +96,19 @@ local function ApplyTransmog(invSlotID, slot, transmogID, illusionID)
     local transmogType, option, displayType;
 
     if invSlotID == 16 or invSlotID == 17 then
-        --Weapon option isn't saved, so resolve it live. Artifact appearances need their own option, not generic.
+        --Weapon option isn't saved, so resolve it live. Match against transmogID so main and off
+        --hand don't end up with swapped artifact options.
         if slot and transmogID and TransmogDataProvider:IsLegionArtifactBySourceID(transmogID) then
             local _, artifactOptionsInfo = GetWeaponOptionsForSlot(slot);
             if artifactOptionsInfo then
+                local appearanceType = Enum.TransmogType.Appearance;
                 for _, optionInfo in ipairs(artifactOptionsInfo) do
                     if optionInfo.enabled then
-                        option = optionInfo.weaponOption;
-                        break;
+                        local slotInfo = GetViewedOutfitSlotInfo(slot, appearanceType, optionInfo.weaponOption);
+                        if slotInfo and slotInfo.transmogID == transmogID then
+                            option = optionInfo.weaponOption;
+                            break;
+                        end
                     end
                 end
             end
@@ -164,45 +170,59 @@ function TransmogUIManager:SetPendingFromTransmogInfoList(transmogInfoList)
     local wardrobeCollection = TransmogFrame and TransmogFrame.WardrobeCollection;
     local tabToRestore = wardrobeCollection and wardrobeCollection:GetTab();
 
-    for invSlotID, transmogInfo in ipairs(transmogInfoList) do
-        if not IgnoredInvSlots[invSlotID] then
-            local transmogID = transmogInfo.appearanceID;
-            local secondaryAppearanceID = transmogInfo.secondaryAppearanceID;
-            local illusionID = transmogInfo.illusionID;
+    local function ApplyOnce()
+        for invSlotID, transmogInfo in ipairs(transmogInfoList) do
+            if not IgnoredInvSlots[invSlotID] then
+                local transmogID = transmogInfo.appearanceID;
+                local secondaryAppearanceID = transmogInfo.secondaryAppearanceID;
+                local illusionID = transmogInfo.illusionID;
 
-            if invSlotID ~= 16 and invSlotID ~= 17 then
-                illusionID = nil;
-            end
-
-            if invSlotID == 17 then
-                --Paired Legion Artifact off-hands derive their appearance from the main-hand, not their own.
-                local mainHandInfo = transmogInfoList[16];
-                if mainHandInfo and mainHandInfo.secondaryAppearanceID == MainHandTransmogIsPairedWeapon then
-                    transmogID = GetPairedArtifactAppearance(mainHandInfo.appearanceID) or transmogID;
+                if invSlotID ~= 16 and invSlotID ~= 17 then
+                    illusionID = nil;
                 end
-            end
 
-            if invSlotID == 3 then
-                --Must run before the appearances below are applied. Toggling it afterward
-                --wipes the left shoulder's pending value.
-                local needsSplitShoulders = secondaryAppearanceID ~= 0 and secondaryAppearanceID ~= transmogID;
-                SetSecondarySlotState(Enum.TransmogOutfitSlot.ShoulderRight, needsSplitShoulders);
-
-                ApplyTransmog(invSlotID, Enum.TransmogOutfitSlot.ShoulderRight, transmogID);
-                if secondaryAppearanceID == 0 then
-                    secondaryAppearanceID = transmogID;
+                if invSlotID == 17 then
+                    --Paired Legion Artifact off-hands derive their appearance from the main-hand, not their own.
+                    local mainHandInfo = transmogInfoList[16];
+                    if mainHandInfo and mainHandInfo.secondaryAppearanceID == MainHandTransmogIsPairedWeapon then
+                        transmogID = GetPairedArtifactAppearance(mainHandInfo.appearanceID) or transmogID;
+                    end
                 end
-                ApplyTransmog(invSlotID, Enum.TransmogOutfitSlot.ShoulderLeft, secondaryAppearanceID);
-            else
-                local slot = ConverInvSlotToTransmogSlot(invSlotID);
-                ApplyTransmog(invSlotID, slot, transmogID, illusionID);
+
+                if invSlotID == 3 then
+                    --Must run before the appearances below are applied. Toggling it afterward
+                    --wipes the left shoulder's pending value.
+                    local needsSplitShoulders = secondaryAppearanceID ~= 0 and secondaryAppearanceID ~= transmogID;
+                    SetSecondarySlotState(Enum.TransmogOutfitSlot.ShoulderRight, needsSplitShoulders);
+
+                    ApplyTransmog(invSlotID, Enum.TransmogOutfitSlot.ShoulderRight, transmogID);
+                    if secondaryAppearanceID == 0 then
+                        secondaryAppearanceID = transmogID;
+                    end
+                    ApplyTransmog(invSlotID, Enum.TransmogOutfitSlot.ShoulderLeft, secondaryAppearanceID);
+                else
+                    local slot = ConverInvSlotToTransmogSlot(invSlotID);
+                    ApplyTransmog(invSlotID, slot, transmogID, illusionID);
+                end
             end
         end
     end
 
-    if wardrobeCollection and tabToRestore and wardrobeCollection:GetTab() ~= tabToRestore then
-        wardrobeCollection:SetTab(tabToRestore);
+    local function RestoreTab()
+        if wardrobeCollection and tabToRestore and wardrobeCollection:GetTab() ~= tabToRestore then
+            wardrobeCollection:SetTab(tabToRestore);
+        end
     end
+
+    ApplyOnce();
+    RestoreTab();
+
+    --Artifact options only resolve once already pending, which needs a frame to settle, so redo next frame.
+    RunNextFrame(function()
+        ApplyOnce();
+		-- Restore the tab for good measure, if it's not necessary this won't do anything.
+        RestoreTab();
+    end);
 end
 
 local UsableItemModifiedAppearances = {};
@@ -730,7 +750,6 @@ do  --Viewd Outfit Info
             };
         end
 
-        local GetViewedOutfitSlotInfo = C_TransmogOutfitInfo.GetViewedOutfitSlotInfo;
         local usedTextures = {};
         local tbl = {};
         local n = 0;

--- a/Narcissus/Modules/TransmogUI/Preload.lua
+++ b/Narcissus/Modules/TransmogUI/Preload.lua
@@ -160,6 +160,10 @@ end
 function TransmogUIManager:SetPendingFromTransmogInfoList(transmogInfoList)
     --Applied per-slot rather than via SetOutfitToCustomSet, for correct illusion/weapon option/shoulder-split
 
+    --Toggling shoulder split below can force-switch the tab back to Items. Restore it after.
+    local wardrobeCollection = TransmogFrame and TransmogFrame.WardrobeCollection;
+    local tabToRestore = wardrobeCollection and wardrobeCollection:GetTab();
+
     for invSlotID, transmogInfo in ipairs(transmogInfoList) do
         if not IgnoredInvSlots[invSlotID] then
             local transmogID = transmogInfo.appearanceID;
@@ -194,6 +198,10 @@ function TransmogUIManager:SetPendingFromTransmogInfoList(transmogInfoList)
                 ApplyTransmog(invSlotID, slot, transmogID, illusionID);
             end
         end
+    end
+
+    if wardrobeCollection and tabToRestore and wardrobeCollection:GetTab() ~= tabToRestore then
+        wardrobeCollection:SetTab(tabToRestore);
     end
 end
 


### PR DESCRIPTION
- Weapon type (1H/2H/ranged/etc.) now resolves from the equipped weapon instead of defaulting to none.
- Legion Artifact appearances apply to the Artifact slot instead of the generic 2H/1H slot.
- Weapon illusions apply again when loading a set.
- Paired Legion Artifact off-hand appearances resolve correctly.
- Separate shoulders toggles on/off automatically to match the set.
- Blizzard's native Custom Sets now apply through the same path as Shared and Alt-Character sets, gaining:
  - Illusions now stick after loading a Custom Set (previously dropped).
  - Separate shoulders now toggles correctly for Custom Sets (previously never toggled, only the appearances applied).

https://github.com/user-attachments/assets/fe657d4c-cb1d-43fb-91a6-becda47fbcbf
